### PR TITLE
Fix V3118

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -42,7 +42,7 @@ namespace excel2json
             Console.WriteLine(
                 string.Format("[{0}]：\t转换完成[{1}毫秒].",
                 Path.GetFileName(options.ExcelPath),
-                dur.Milliseconds)
+                dur.TotalMilliseconds)
                 );
         }
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning:

- V3118 Milliseconds component of 'dur' is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. excel2json Program.cs 45